### PR TITLE
🐛 FIX: Correction des liens vers les images

### DIFF
--- a/src/data/livres.json
+++ b/src/data/livres.json
@@ -2,11 +2,11 @@
   {
     "id": "1a23bc45",
     "title": "Le Petit Prince",
-    "cover": "https://kyra110.github.io/entrainementP8/images/petit/petit-prince-cover.webp",
+    "cover": "./images/petit/petit-prince-cover.webp",
     "pictures":[
-      "https://kyra110.github.io/entrainementP8/images/petit/petit-prince-picture1.webp",
-      "https://kyra110.github.io/entrainementP8/images/petit/petit-prince-picture2.webp",
-      "https://kyra110.github.io/entrainementP8/images/petit/petit-prince-picture3.webp"
+      "../images/petit/petit-prince-picture1.webp",
+      "../images/petit/petit-prince-picture2.webp",
+      "../images/petit/petit-prince-picture3.webp"
     ],
     "author": "Antoine de Saint-Exupéry",
     "description": "Un conte poétique et philosophique qui raconte l'histoire d'un petit prince venu d'une planète lointaine.",
@@ -20,11 +20,11 @@
   {
     "id": "6d78ef90",
     "title": "Harry Potter à l'école des sorciers",
-    "cover": "https://kyra110.github.io/entrainementP8/images/harry/harry-cover.webp",
+    "cover": "./images/harry/harry-cover.webp",
     "pictures":[
-      "https://kyra110.github.io/entrainementP8/images/harry/harry-picture1.webp",
-      "https://kyra110.github.io/entrainementP8/images/harry/harry-picture2.webp",
-      "https://kyra110.github.io/entrainementP8/images/harry/harry-picture3.webp"
+      "../images/harry/harry-picture1.webp",
+      "../images/harry/harry-picture2.webp",
+      "../images/harry/harry-picture3.webp"
     ],
     "author": "J.K. Rowling",
     "description": "L'histoire magique de Harry Potter, un jeune sorcier découvrant le monde de la sorcellerie à l'école de Poudlard.",


### PR DESCRIPTION
La raison pour laquelle il n'est pas possible de mettre des chemins absolus pour les images vient du fait que les GitHub pages sont hébergées sous la forme `github.io/XXX`. La racine n'est donc pas directement disponible car le code est dans le "dossier" **XXX**.

Il faut donc préférer des chemins relatifs dans le fichier `src/data/livres.json`.

La cover étant affichée sur la home `/`, le dossier `images` est directement accessible, le chemin vers la cover commence par `./images/...`.

Les pictures sont affichées sur la page `/livre`, le dossier `images` est un cran plus haut dans l'arborescence, il faut donc faire commencer le chemin par `../images/...`